### PR TITLE
Add PR reference into the outputs and clone specs internally

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -129,12 +129,14 @@ rm geckodriver-v0.26.0-macos.tar.gz
 
 ### Executando os testes do corretor
 
-- Antes de executar os testes do corretor é necessário clonar o repositório a ser corrigido dentro do diretório `spec`
+- Antes de executar os testes do corretor é necessário clonar o repositório a ser corrigido dentro do diretório `spec` e clonar o repositório dos testes dentro do repositório a ser corrigido
 
     ```
     cd spec/
     git clone git@github.com:tryber/<project-repo-name>.git
-    cd ..
+    cd <project-repo-name>
+    git clone git@github.com:tryber/<project-repo-name>-tests.git
+    cd ../../
     ```
 
 - Para executar os testes basta utilizar o `rspec` com as variáveis de ambiente necessárias
@@ -151,8 +153,9 @@ Caso queira executar o corretor com o Docker para não precisar configurar seu a
 2. Clone o projeto: `git clone git@github.com:betrybe/capybara-evaluator-action.git`
 3. Entre no diretório dos testes do corretor: `cd capybara-evaluator-action/spec/`
 4. Clone o repositório a ser corrigido: `git clone git@github.com:tryber/<project-repo-name>.git`
-5. Volte ao diretório raiz do corretor: `cd ..`
-6. Crie a imagem do docker: `sudo docker build -t capybara-evaluator .`
+5. Clone o repositório dos testes dentro do repositório a ser corrigido: `cd <project-repo-name> && git clone git@github.com:tryber/<project-repo-name>.git`
+6. Volte ao diretório raiz do corretor: `cd ../../`
+7. Crie a imagem do docker: `sudo docker build -t capybara-evaluator .`
 
 Após configurar o docker, para executar os testes basta utilizar o comando abaixo:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Arquivo JSON em formato base64 com a saída avaliada pelo RSpec.
 
 Arquivo JSON em formato base64 com o resultado, em notas por requisito, dos testes executados.
 
+### `pr-number`
+
+Número da Pull Request que disparou a build.
+
 ## Exemplo de uso
 ```yml
 uses: betrybe/capybara-evaluator-action

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ outputs:
     description: 'Evaluation JSON file in Base64 format'
   result:
     description: 'Tests results JSON file in base64 format'
+  pr-number:
+    description: 'Pull Request number that triggered the build'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,5 +20,6 @@ then
   exit 1
 fi
 
-echo ::set-output name=result::`cat result.json | base64 -w 0`
 echo ::set-output name=evaluation::`cat evaluation.json | base64 -w 0`
+echo ::set-output name=result::`cat result.json | base64 -w 0`
+echo ::set-output name=pr-number::$(echo "$GITHUB_REF" | awk -F / '{print $3}')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 
 if [ $GITHUB_ACTIONS ]
 then
+  git clone https://github.com/$GITHUB_REPOSITORY-tests.git /project-tests
+  rm -rf /project-tests/.git
+  cp -r /project-tests/* .
   mv requirements_mapping.json /capybara_evaluator_action/
   mkdir /capybara_evaluator_action/spec/$GITHUB_REPOSITORY -p
   mv ./* /capybara_evaluator_action/spec/$GITHUB_REPOSITORY/


### PR DESCRIPTION
When merged this PR will:

- [x] Add the PR reference number into the outputs;
- [x] Clone the specs internally to prevent the students from removing the project tests.